### PR TITLE
Make script compatible with non-root encrypted volume

### DIFF
--- a/key-script
+++ b/key-script
@@ -27,7 +27,11 @@ check_yubikey_present() {
 udevadm settle || true
 
 # source for log_*_msg() functions, see LP: #272301
-. /scripts/functions
+if [ -e /scripts/functions ] ; then
+	. /scripts/functions
+else
+	. /usr/share/initramfs-tools/scripts/functions
+fi
 
 if [ -z "$cryptkeyscript" ]; then
 	cryptkey="Unlocking the disk $cryptsource ($crypttarget)\nEnter passphrase: "


### PR DESCRIPTION
Hi, I made this change to the script on my laptop so it would work with an encrypted non-root volume (/ is not encrypted).

This change should make the script compatible with being called as the keyfile= parameter in /etc/crypttab, for example when /home is luks-encrypted but not /.

It calls /usr/share/initramfs-tools/scripts/functions instead of /scripts/functions if the latter doesn't exist (which it won't when called in this way).

Note I've not tested this change with an encrypted root as I don't have one.

This is my very first github pull request!! :)