### PR TITLE
Concatenate challenge + response

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ this:
 	bd438575f4e8df965c80363f8aa6fe1debbe9ea9
 it can be used as normal password.
 
+If you set CONCATENATE=1 option in the file /etc/ykluks.cfg then both your password and Yubikey response will be bundled together and written to key slot: passwordbd438575f4e8df965c80363f8aa6fe1debbe9ea9
+
 Changing the welcome text
 -------------------------
 

--- a/key-script
+++ b/key-script
@@ -45,7 +45,11 @@ if check_yubikey_present; then
 	message "Accessing yubikey..."
     R="$(ykchalresp -2 "$PW" 2>/dev/null || true)"
 	message "Retrieved the response from the Yubikey"
-	echo -n "$PW$R"
+	if [ "$CONCATENATE" = "1" ]; then
+		echo -n "$PW$R"
+	else
+	        echo -n "$R"
+	fi
 else
 	echo -n "$PW"
 fi

--- a/key-script
+++ b/key-script
@@ -45,7 +45,7 @@ if check_yubikey_present; then
 	message "Accessing yubikey..."
     R="$(ykchalresp -2 "$PW" 2>/dev/null || true)"
 	message "Retrieved the response from the Yubikey"
-	echo -n "$R"
+	echo -n "$PW$R"
 else
 	echo -n "$PW"
 fi

--- a/ykluks.cfg
+++ b/ykluks.cfg
@@ -1,4 +1,5 @@
 # If you change this file, you need to run 
 #   update-initramfs -u
 WELCOME_TEXT="Please insert yubikey and press enter or enter a valid passphrase"
+# Set to "1" if you want both your password and Yubikey response be bundled together and writtent to key slot.
 CONCATENATE=0

--- a/ykluks.cfg
+++ b/ykluks.cfg
@@ -1,3 +1,4 @@
 # If you change this file, you need to run 
 #   update-initramfs -u
 WELCOME_TEXT="Please insert yubikey and press enter or enter a valid passphrase"
+CONCATENATE=0

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -51,7 +51,7 @@ echo "You may now be prompted for an existing passphrase. This is NOT the passph
 R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"
 touch $TMP_FILE
 chmod 600 $TMP_FILE
-echo -n "$R" > $TMP_FILE
+echo -n "$P1$R" > $TMP_FILE
 cryptsetup --key-slot=$SLOT luksAddKey $DISK $TMP_FILE
 rm $TMP_FILE
 exit 0

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -4,7 +4,7 @@ DISK="/dev/sda3"
 CLEAR_SLOT=0
 TMP_FILE=/tmp/new_key
 set -e
-
+. /etc/ykluks.cfg
 
 
 while getopts ":s:d:hc" opt; do
@@ -51,7 +51,11 @@ echo "You may now be prompted for an existing passphrase. This is NOT the passph
 R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"
 touch $TMP_FILE
 chmod 600 $TMP_FILE
-echo -n "$P1$R" > $TMP_FILE
+if [ "$CONCATENATE" = "1" ]; then
+	echo -n "$P1$R" > $TMP_FILE
+else
+	echo -n "$R" > $TMP_FILE
+fi
 cryptsetup --key-slot=$SLOT luksAddKey $DISK $TMP_FILE
 rm $TMP_FILE
 exit 0


### PR DESCRIPTION
This PR resolves https://github.com/cornelinux/yubikey-luks/issues/15 . It's very simple as it uses actual challenge-response scheme and doesn't need any new special preparation except enrolling new luks key with `yubikey-luks-enroll`.

As it definitely increases security of luks key I think it's safe to merge regardless if any future solution will come or not.

I disabled concatenation by default so it will be safe to upgrade for any existing users.