### PR TITLE
Add option for hashing password with sha256

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ it can be used as normal password.
 
 If you set CONCATENATE=1 option in the file /etc/ykluks.cfg then both your password and Yubikey response will be bundled together and written to key slot: passwordbd438575f4e8df965c80363f8aa6fe1debbe9ea9
 
+If you set HASH=1 option in the file /etc/ykluks.cfg then your password will be hashed with sha256 algorithm before using as challenge for yubikey: printf password | sha256sum | awk '{print $1}'
+5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
+
 Changing the welcome text
 -------------------------
 

--- a/key-script
+++ b/key-script
@@ -40,7 +40,11 @@ if [ -z "$cryptkeyscript" ]; then
 fi
 
 PW="$($cryptkeyscript "$WELCOME_TEXT")"
-	
+
+if [ "$HASH" = "1" ]; then
+	PW=$(printf %s "$PW" | sha256sum | awk '{print $1}')
+fi
+
 if check_yubikey_present; then
 	message "Accessing yubikey..."
     R="$(ykchalresp -2 "$PW" 2>/dev/null || true)"

--- a/ykluks.cfg
+++ b/ykluks.cfg
@@ -3,3 +3,5 @@
 WELCOME_TEXT="Please insert yubikey and press enter or enter a valid passphrase"
 # Set to "1" if you want both your password and Yubikey response be bundled together and writtent to key slot.
 CONCATENATE=0
+# Set to "1" if you want to hash your password with sha256.
+HASH=0

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -46,6 +46,11 @@ P2=$(/lib/cryptsetup/askpass "Please enter the yubikey password again:")
 if [ "$P1" != "$P2" ]; then
 	echo "Passwords do not match"
 	exit 1
+
+if [ "$HASH" = "1" ]; then
+	P1=$(printf %s "$P1" | sha256sum | awk '{print $1}') 
+fi
+
 fi
 echo "You may now be prompted for an existing passphrase. This is NOT the passphrase you just entered, this is the passphrase that you currently use to unlock your LUKS encrypted drive."
 R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"


### PR DESCRIPTION
Using password as challenge can have some drawbacks.

1. Password can be very weak like "aaa"
2. Password can be longer than 64 characters which is max for yubikey challenge which result in breakage.

As solution we can hash the password with sha256 which give us 64 characters (maximum) length challenge for any user provided password.

Using along `CONCATENATE` will result in 104 (64+40) characters long LUKS passphrase

It will be disabled by default to have backward compatibility for existing users.