### PR TITLE
Add yubikey-luks-open script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ After changing this file, you need to run
 
 so that the changes get transferred to the initramfs.
 
+Open LUKS container protected with yubikey-luks
+------------------------------------
+
+You can open LUKS container protected with yubikey-luks on running system
+
+        yubikey-luks-open
+
+
 Manage several Yubikeys and Machines
 ------------------------------------
 

--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,7 @@ override_dh_install:
 	install -D -o root -g root -m755 script-top debian/yubikey-luks/usr/share/initramfs-tools/scripts/local-top/yubikey-luks
 	install -D -o root -g root -m755 script-bottom debian/yubikey-luks/usr/share/initramfs-tools/scripts/local-bottom/yubikey-luks
 	install -D -o root -g root -m755 key-script debian/yubikey-luks/usr/share/yubikey-luks/ykluks-keyscript
+	install -D -o root -g root -m755 yubikey-luks-open debian/yubikey-luks/usr/bin/yubikey-luks-open
 	install -D -o root -g root -m755 yubikey-luks-enroll debian/yubikey-luks/usr/bin/yubikey-luks-enroll
 	install -D -o root -g root -m644 yubikey-luks-enroll.1 debian/yubikey-luks/usr/man/man1/yubikey-luks-enroll.1
 	install -D -o root -g root -m644 ykluks.cfg debian/yubikey-luks/etc/ykluks.cfg

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -32,8 +32,8 @@ while getopts ":s:d:hcv" opt; do
 		echo 
 		echo " -d <partition>: set the partition"
 		echo " -s <slot>     : set the slot"
-                echo " -c            : clear the slot prior to writing"
-                echo " -v            : show input/output in cleartext"
+		echo " -c            : clear the slot prior to writing"
+		echo " -v            : show input/output in cleartext"
 		echo
 		exit 1
 		;;

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -3,7 +3,7 @@ SLOT=7
 DISK="/dev/sda3"
 CLEAR_SLOT=0
 DBG=0
-TMP_FILE=/tmp/new_key
+
 set -e
 . /etc/ykluks.cfg
 
@@ -71,18 +71,12 @@ echo "You may now be prompted for an existing passphrase. This is NOT the passph
 R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"
 	if [ "$DBG" = "1" ]; then echo "Yubikey response: $R"; fi
 
-touch $TMP_FILE
-chmod 600 $TMP_FILE
-
 if [ "$CONCATENATE" = "1" ]; then
-	echo -n "$P1$R" > $TMP_FILE
+	printf %s "$P1$R" | cryptsetup luksOpen "$DISK" "$NAME" 2>&1;
 		if [ "$DBG" = "1" ]; then echo "LUKS key: $P1$R"; fi
 else
-	echo -n "$R" > $TMP_FILE
+	printf %s "$R" | cryptsetup luksOpen "$DISK" "$NAME" 2>&1;
 		if [ "$DBG" = "1" ]; then echo "LUKS key: $R"; fi
 fi
-
-cryptsetup --key-slot="$SLOT" luksAddKey "$DISK" $TMP_FILE
-shred -u $TMP_FILE
 
 exit 0

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -3,7 +3,7 @@ SLOT=7
 DISK="/dev/sda3"
 CLEAR_SLOT=0
 DBG=0
-
+TMP_FILE=/tmp/new_key
 set -e
 . /etc/ykluks.cfg
 
@@ -71,12 +71,18 @@ echo "You may now be prompted for an existing passphrase. This is NOT the passph
 R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"
 	if [ "$DBG" = "1" ]; then echo "Yubikey response: $R"; fi
 
+touch $TMP_FILE
+chmod 600 $TMP_FILE
+
 if [ "$CONCATENATE" = "1" ]; then
-	printf %s "$P1$R" | cryptsetup luksOpen "$DISK" "$NAME" 2>&1;
+	echo -n "$P1$R" > $TMP_FILE
 		if [ "$DBG" = "1" ]; then echo "LUKS key: $P1$R"; fi
 else
-	printf %s "$R" | cryptsetup luksOpen "$DISK" "$NAME" 2>&1;
+	echo -n "$R" > $TMP_FILE
 		if [ "$DBG" = "1" ]; then echo "LUKS key: $R"; fi
 fi
+
+cryptsetup --key-slot="$SLOT" luksAddKey "$DISK" $TMP_FILE
+shred -u $TMP_FILE
 
 exit 0

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -3,7 +3,7 @@ SLOT=7
 DISK="/dev/sda3"
 CLEAR_SLOT=0
 DBG=0
-TMP_FILE=/tmp/new_key
+
 set -e
 . /etc/ykluks.cfg
 
@@ -67,22 +67,18 @@ if [ "$HASH" = "1" ]; then
 		if [ "$DBG" = "1" ]; then echo "Password hash: $P1"; fi
 fi
 
-echo "You may now be prompted for an existing passphrase. This is NOT the passphrase you just entered, this is the passphrase that you currently use to unlock your LUKS encrypted drive."
 R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"
 	if [ "$DBG" = "1" ]; then echo "Yubikey response: $R"; fi
 
-touch $TMP_FILE
-chmod 600 $TMP_FILE
+OLD=$(/lib/cryptsetup/askpass "Please provide an existing passphrase. This is NOT the passphrase you just entered, this is the passphrase that you currently use to unlock your LUKS encrypted drive:")
+	if [ "$DBG" = "1" ]; then echo "Old passphrase: $OLD"; fi
 
 if [ "$CONCATENATE" = "1" ]; then
-	echo -n "$P1$R" > $TMP_FILE
+	printf '%s\n' "$OLD" "$P1$R" "$P1$R" | cryptsetup --key-slot="$SLOT" luksAddKey "$DISK" 2>&1;
 		if [ "$DBG" = "1" ]; then echo "LUKS key: $P1$R"; fi
 else
-	echo -n "$R" > $TMP_FILE
+	printf '%s\n' "$OLD" "$R" "$R" | cryptsetup --key-slot="$SLOT" luksAddKey "$DISK" 2>&1;
 		if [ "$DBG" = "1" ]; then echo "LUKS key: $R"; fi
 fi
-
-cryptsetup --key-slot="$SLOT" luksAddKey "$DISK" $TMP_FILE
-shred -u $TMP_FILE
 
 exit 0

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -28,7 +28,7 @@ while getopts ":d:n:hv" opt; do
 		echo 
 		echo " -d <partition>: set the partition"
 		echo " -n <name>     : set the container name"
-                echo " -v            : show input/output in cleartext"
+		echo " -v            : show input/output in cleartext"
 		echo
 		exit 1
 		;;

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -26,7 +26,7 @@ while getopts ":d:n:hv" opt; do
 		;;
 	h)
 		echo 
-		echo " -d <partition>: set the existing partition"
+		echo " -d <partition>: select existing partition"
 		echo " -n <name>     : set the new container name"
 		echo " -v            : show input/output in cleartext"
 		echo

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -2,7 +2,7 @@
 DISK="/dev/sda3"
 NAME="yubikey-luks"
 DBG=0
-TMP_FILE=/tmp/new_key
+
 set -e
 . /etc/ykluks.cfg
 
@@ -51,18 +51,12 @@ fi
 R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"
 	if [ "$DBG" = "1" ]; then echo "Yubikey response: $R"; fi
 
-touch $TMP_FILE
-chmod 600 $TMP_FILE
-
 if [ "$CONCATENATE" = "1" ]; then
-	echo -n "$P1$R" > $TMP_FILE
+	printf %s "$P1$R" | cryptsetup luksOpen "$DISK" "$NAME" 2>&1;
 		if [ "$DBG" = "1" ]; then echo "LUKS key: $P1$R"; fi
 else
-	echo -n "$R" > $TMP_FILE
+	printf %s "$R" | cryptsetup luksOpen "$DISK" "$NAME" 2>&1;
 		if [ "$DBG" = "1" ]; then echo "LUKS key: $R"; fi
 fi
-
-cryptsetup --key-file=$TMP_FILE luksOpen "$DISK" "$NAME"
-shred -u $TMP_FILE
 
 exit 0

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -26,8 +26,8 @@ while getopts ":d:n:hv" opt; do
 		;;
 	h)
 		echo 
-		echo " -d <partition>: set the partition"
-		echo " -n <name>     : set the container name"
+		echo " -d <partition>: set the existing partition"
+		echo " -n <name>     : set the new container name"
 		echo " -v            : show input/output in cleartext"
 		echo
 		exit 1

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -1,0 +1,68 @@
+#!/bin/sh
+DISK="/dev/sda3"
+NAME="yubikey-luks"
+DBG=0
+TMP_FILE=/tmp/new_key
+set -e
+. /etc/ykluks.cfg
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "You must be root." 1>&2
+  exit 1
+fi
+
+while getopts ":d:n:hv" opt; do
+  case $opt in
+	d)
+		DISK=$OPTARG
+		echo "setting disk to $OPTARG."
+		;;
+	n)
+		NAME=$OPTARG
+		echo "setting name to $OPTARG."
+		;;
+		v)      DBG=1
+		echo "debugging enabled"
+		;;
+	h)
+		echo 
+		echo " -d <partition>: set the partition"
+		echo " -n <name>     : set the container name"
+                echo " -v            : show input/output in cleartext"
+		echo
+		exit 1
+		;;
+	\?)
+		echo "Invalid option: -$OPTARG" >&2
+		;;
+  esac
+done
+
+echo "This script will try opening $NAME LUKS container on drive $DISK . If this is not what you intended, exit now!"
+
+P1=$(/lib/cryptsetup/askpass "Please insert a yubikey and enter password created with yubikey-luks-enroll.")
+	if [ "$DBG" = "1" ]; then echo "Password: $P1"; fi
+
+if [ "$HASH" = "1" ]; then
+	P1=$(printf %s "$P1" | sha256sum | awk '{print $1}')
+		if [ "$DBG" = "1" ]; then echo "Password hash: $P1"; fi
+fi
+
+R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"
+	if [ "$DBG" = "1" ]; then echo "Yubikey response: $R"; fi
+
+touch $TMP_FILE
+chmod 600 $TMP_FILE
+
+if [ "$CONCATENATE" = "1" ]; then
+	echo -n "$P1$R" > $TMP_FILE
+		if [ "$DBG" = "1" ]; then echo "LUKS key: $P1$R"; fi
+else
+	echo -n "$R" > $TMP_FILE
+		if [ "$DBG" = "1" ]; then echo "LUKS key: $R"; fi
+fi
+
+cryptsetup --key-file=$TMP_FILE luksOpen "$DISK" "$NAME"
+shred -u $TMP_FILE
+
+exit 0


### PR DESCRIPTION
It allows for opening LUKS containers protected with yubikey-luks outside initramfs. It's useful for external encrypted disks or system rescue in case of broken initramfs.