### PR TITLE
Use udisksctl and expect to unlock encrypted volume without needing supeuser privileges

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.8.3
 
 Package: yubikey-luks
 Architecture: all
-Depends: initramfs-tools, yubikey-personalization (>= 1.5), yubikey-personalization
+Depends: initramfs-tools, yubikey-personalization (>= 1.5), yubikey-personalization, udisks2, expect
 Description: Yubikey two factor authentication with LUKS
  Using the Yubikey in challenge response mode to
  do two factor authentication with LUKS.

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -6,11 +6,6 @@ DBG=0
 set -e
 . /etc/ykluks.cfg
 
-if [ "$(id -u)" -ne 0 ]; then
-  echo "You must be root." 1>&2
-  exit 1
-fi
-
 while getopts ":d:n:hv" opt; do
   case $opt in
 	d)
@@ -21,7 +16,8 @@ while getopts ":d:n:hv" opt; do
 		NAME=$OPTARG
 		echo "setting name to $OPTARG."
 		;;
-        v)      DBG=1
+	v)
+		DBG=1
 		echo "debugging enabled"
 		;;
 	h)
@@ -51,12 +47,45 @@ fi
 R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"
 	if [ "$DBG" = "1" ]; then echo "Yubikey response: $R"; fi
 
+_passphrase=''
 if [ "$CONCATENATE" = "1" ]; then
-	printf %s "$P1$R" | cryptsetup luksOpen "$DISK" "$NAME" 2>&1;
-		if [ "$DBG" = "1" ]; then echo "LUKS key: $P1$R"; fi
+	_passphrase=$(printf '%s' "$P1$R")
 else
-	printf %s "$R" | cryptsetup luksOpen "$DISK" "$NAME" 2>&1;
-		if [ "$DBG" = "1" ]; then echo "LUKS key: $R"; fi
+	_passphrase=$(printf '%s' "$R")
+fi
+	if [ "$DBG" = "1" ]; then echo "LUKS key: ${_passphrase}"; fi
+
+if [ "$(id -u)" -eq 0 ]; then
+	printf %s "${_passphrase}" | cryptsetup luksOpen "$DISK" "$NAME" 2>&1;
+else
+	# c-style escapes are not available in sh, so instead of doing symply
+	# $'\n' we have to put a newline in a variable, see:
+	#   https://github.com/koalaman/shellcheck/wiki/SC2039
+	_n="$(printf '%b_' '\n')"
+	_n="${_n%_}"
+
+	# reading a HEREDOC to a variable in a POSIX-compliant shell, see:
+	#   https://unix.stackexchange.com/a/340907/162158
+	# basically, the while loop reads the HEREDOC line-by-line (IFS set to
+	# newline) and concatenates everything in a variable and adds a newline.
+	expect_script=''
+	OLDIFS="$IFS"
+    while IFS="${_n}" read -r line; do
+        expect_script="$expect_script$line${_n}"
+    done <<EXPECTSCRIPT
+		set timeout -1;
+		spawn udisksctl unlock -b "$DISK";
+		match_max 100000;
+		expect -exact "Passphrase: ";
+		send -- "${_passphrase}\\r";
+		expect eof
+EXPECTSCRIPT
+	# get rid of all tabs and convert newlines to spaces in the expect script,
+	# otherwise it will break when it is piped to expect
+	expect_script=$(echo "$expect_script" | tr -d '\t' | tr '\n' ' ')
+	IFS="$OLDIFS"
+
+	echo "$expect_script" | expect -f -
 fi
 
 exit 0


### PR DESCRIPTION
Coming from this PR [[1]], this pull request does the same for this project.

One caveat, I could not test it because I am already using @agherzan's [yubikey-full-disk-encryption](https://github.com/agherzan/yubikey-full-disk-encryption), but it should work (granted, it has needed some adaptations given the differences between `bash` and `sh`).

As said in the [original PR][1], this project adds a dependency on [`expect`](https://linux.die.net/man/1/expect), which is packaged in Debian, its derivatives, and in many other distros.

[1]:  https://github.com/agherzan/yubikey-full-disk-encryption/pull/17