### PR TITLE
Add NO_SIGN option to avoid signing deb package, update README:md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 info:
-	@echo "builddeb        - building debian package for Ubuntu LTS"
-	@echo "builddeb-nosign - building debian package for Ubuntu LTS WITHOUT SIGNING"
-	@echo "ppa-dev         - upload to ppa launchpad. Development"
-	@echo "ppa	       - upload to ppa launchpad. Stable"
+	@echo "builddeb [NO_SIGN=1]  - build deb package for Ubuntu LTS [NO_SIGN disables signing]"
+	@echo "clean                 - clean build directory DEBUILD"
+	@echo "ppa-dev               - upload to ppa launchpad. Development"
+	@echo "ppa                   - upload to ppa launchpad. Stable"
 
 VERSION=0.5.1
 SRC_DIR = yubikey_luks.orig
@@ -15,11 +15,11 @@ debianize:
 
 builddeb:
 	make debianize
+ifndef NO_SIGN
 	(cd DEBUILD/${SRC_DIR}; debuild)
-
-builddeb-nosign:
-	make debianize
+else
 	(cd DEBUILD/${SRC_DIR}; debuild -uc -us)
+endif
 
 ppa-dev:
 	make debianize
@@ -33,4 +33,5 @@ ppa:
 	# Upload to launchpad:
 	dput ppa:privacyidea/privacyidea DEBUILD/yubikey-luks_${VERSION}-?_source.changes
 
-
+clean:
+	rm -fr DEBUILD

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Initialize the Yubikey for challenge response in slot 2
 install package
 ---------------
 
-Build the package:
+Build the package (without signing it):
 
-	make builddeb
+	make builddeb NO_SIGN=1
 
 Install the package:
 


### PR DESCRIPTION
Hi,

This pull request adds the possibility to define a `NO_SIGN` so that the deb file is not signed. I have also added a `clean`, so that you can do `make clean` to remove the `DEBUILD` directory.

This pull-request also updates the `README.md`.
