### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/key-script
+++ b/key-script
@@ -12,7 +12,7 @@ fi
 message()
 {
     if [ -x /bin/plymouth ] && plymouth --ping; then
-        plymouth message --text="$@"
+        plymouth message --text="$*"
     else
         echo "$@" >&2
     fi
@@ -34,10 +34,10 @@ else
 fi
 
 if [ -z "$cryptkeyscript" ]; then
-	cryptkey="Unlocking the disk $cryptsource ($crypttarget)\nEnter passphrase: "
+	cryptkey="Unlocking the disk $cryptsource ($crypttarget)\\nEnter passphrase: "
 	if [ -x /bin/plymouth ] && plymouth --ping; then
     	cryptkeyscript="plymouth ask-for-password --prompt"
-	    cryptkey=$(printf "$cryptkey")
+	    cryptkey=$(printf '%s' "$cryptkey")
     else
         cryptkeyscript="/lib/cryptsetup/askpass"
     fi
@@ -54,12 +54,12 @@ if check_yubikey_present; then
     R="$(ykchalresp -2 "$PW" 2>/dev/null || true)"
 	message "Retrieved the response from the Yubikey"
 	if [ "$CONCATENATE" = "1" ]; then
-		echo -n "$PW$R"
+		printf '%s' "$PW$R"
 	else
-	        echo -n "$R"
+	        printf '%s' "$R"
 	fi
 else
-	echo -n "$PW"
+	printf '%s' "$PW"
 fi
 
 exit 0

--- a/script-bottom
+++ b/script-bottom
@@ -8,7 +8,7 @@ PREREQ=""
 message()
 {
     if [ -x /bin/plymouth ] && plymouth --ping; then
-        plymouth message --text="$@"
+        plymouth message --text="$*"
     else
         echo "$@" >&2
     fi


### PR DESCRIPTION
This PR fixes below warnings detected by [shellcheck](https://www.shellcheck.net/) tool:
```
In key-script line 15:
        plymouth message --text="$@"
                                 ^-- SC2145: Argument mixes string and array. Use * or separate argument.

In key-script line 37:
	cryptkey="Unlocking the disk $cryptsource ($crypttarget)\nEnter passphrase: "
                                                                ^-- SC1117: Backslash is literal in "\n". Prefer explicit escaping: "\\n".


In key-script line 40:
	    cryptkey=$(printf "$cryptkey")
                              ^-- SC2059: Don't use variables in the printf format string. Use printf "..%s.." "$foo".


In key-script line 57:
		echo -n "$PW$R"
                     ^-- SC2039: In POSIX sh, echo flags are undefined.


In key-script line 59:
	        echo -n "$R"
                     ^-- SC2039: In POSIX sh, echo flags are undefined.


In key-script line 62:
	echo -n "$PW"
             ^-- SC2039: In POSIX sh, echo flags are undefined.


```