### PR TITLE
Explicitly add sha256sum binary to initramfs

### DIFF
--- a/hook
+++ b/hook
@@ -19,6 +19,7 @@ esac
 . /usr/share/initramfs-tools/hook-functions
 
 copy_exec /usr/bin/ykchalresp
+copy_exec /usr/bin/sha256sum
 cp /usr/share/yubikey-luks/ykluks-keyscript "${DESTDIR}/sbin/ykluks-keyscript"
 cp /etc/ykluks.cfg "${DESTDIR}/etc/ykluks.cfg"
 cp -pnL /usr/lib/yubikey-luks-suspend/initramfs-suspend "${DESTDIR}/suspend"


### PR DESCRIPTION
On Ubuntu bionic there is no sha256sum binary in initramfs by default. We have to explicitly add it otherwise hash option will be broken.

I had to make new PR as https://github.com/cornelinux/yubikey-luks/pull/30 unfortunately got dirty.
@cornelinux Please merge it.