### PR TITLE
Fix key-script

### DIFF
--- a/key-script
+++ b/key-script
@@ -45,12 +45,11 @@ fi
 
 PW="$($cryptkeyscript "$WELCOME_TEXT")"
 
-if [ "$HASH" = "1" ]; then
-	PW=$(printf %s "$PW" | sha256sum | awk '{print $1}')
-fi
-
 if check_yubikey_present; then
 	message "Accessing yubikey..."
+	if [ "$HASH" = "1" ]; then
+		PW=$(printf %s "$PW" | sha256sum | awk '{print $1}')
+	fi
     R="$(ykchalresp -2 "$PW" 2>/dev/null || true)"
 	message "Retrieved the response from the Yubikey"
 	if [ "$CONCATENATE" = "1" ]; then


### PR DESCRIPTION
If one used the hash function, user input was hashed before testing for the presence of a yubikey, which would feed a sha256 hashed password to the fallback /lib/cryptsetup/askpass if there wasn't a yubikey present, which is probably unexpected and unlikely to result in opening the luks volume. 