### PR TITLE
Add support for custom hashing algorithms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/DEBUILD

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SRC_DIR = yubikey_luks.orig
 debianize:
 	rm -fr DEBUILD
 	mkdir -p DEBUILD/${SRC_DIR}
-	cp -r * DEBUILD/${SRC_DIR} || true
+	cp -r `ls -A | grep -v DEBUILD` DEBUILD/${SRC_DIR} || true
 	(cd DEBUILD; tar -zcf yubikey-luks_${VERSION}.orig.tar.gz --exclude=${SRC_DIR}/debian  ${SRC_DIR})
 
 builddeb:

--- a/README.md
+++ b/README.md
@@ -47,8 +47,18 @@ it can be used as normal password.
 
 If you set CONCATENATE=1 option in the file /etc/ykluks.cfg then both your password and Yubikey response will be bundled together and written to key slot: passwordbd438575f4e8df965c80363f8aa6fe1debbe9ea9
 
-If you set HASH=1 option in the file /etc/ykluks.cfg then your password will be hashed with sha256 algorithm before using as challenge for yubikey: printf password | sha256sum | awk '{print $1}'
+If you set HASH=1 option in the file /etc/ykluks.cfg then your password will be hashed with sha256 algorithm or your configured hashing command before using as challenge for yubikey: printf password | $HASH_COMMAND $HASH_ARGS | awk '{print $1}'
 5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
+
+If you set HASH_COMMAND in the file /etc/ykluks.cfg then your password will be hashed with the custom command instead of sha256sum. This must be the full path to the binary without arguments such as HASH_COMMAND=/usr/bin/custom-hasher
+
+If you set HASH_ARGS in the file /etc/ykluks.cfg the arguments will be passed to $HASH_COMMAND when it is run to hash the password.
+
+```
+HASH_COMMAND=/usr/bin/custom-hasher
+HASH_ARGS="--cost=14 --salt=99bcda088e1aec8934aafb6c7f49f284"
+printf password | /usr/bin/custom-hasher --cost=14 --salt=99bcda088e1aec8934aafb6c7f49f284 | awk '{print $1}'
+```
 
 Changing the welcome text
 -------------------------
@@ -66,7 +76,7 @@ Enable yubikey-luks-suspend module
 ------------------------------------
 
 You can enable yubikey-luks-suspend module which allows for automatically locking encrypted LUKS containers and wiping keys from memory on suspend and unlocking them on resume by using luksSuspend, luksResume commands.
- 
+
         systemctl enable yubikey-luks-suspend.service
 
 Open LUKS container protected with yubikey-luks

--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,7 @@ override_dh_install:
 	install -D -o root -g root -m755 yubikey-luks-enroll debian/yubikey-luks/usr/bin/yubikey-luks-enroll
 	install -D -o root -g root -m644 yubikey-luks-enroll.1 debian/yubikey-luks/usr/man/man1/yubikey-luks-enroll.1
 	install -D -o root -g root -m644 ykluks.cfg debian/yubikey-luks/etc/ykluks.cfg
+	install -D -o root -g root -m644 ykluks-defaults.cfg debian/yubikey-luks/usr/share/yubikey-luks/ykluks-defaults.cfg
 	install -D -o root -g root -m755 yubikey-luks-suspend debian/yubikey-luks/usr/lib/yubikey-luks-suspend/yubikey-luks-suspend
 	install -D -o root -g root -m755 initramfs-suspend debian/yubikey-luks/usr/lib/yubikey-luks-suspend/initramfs-suspend
 	install -D -o root -g root -m644 yubikey-luks-suspend.service debian/yubikey-luks/lib/systemd/system/yubikey-luks-suspend.service

--- a/hook
+++ b/hook
@@ -16,11 +16,15 @@ prereqs)
 	;;
 esac
 
+. /usr/share/yubikey-luks/ykluks-defaults.cfg
+. /etc/ykluks.cfg
+
 . /usr/share/initramfs-tools/hook-functions
 
 copy_exec /usr/bin/ykchalresp
-copy_exec /usr/bin/sha256sum
+copy_exec "$HASH_COMMAND"
 cp /usr/share/yubikey-luks/ykluks-keyscript "${DESTDIR}/sbin/ykluks-keyscript"
+cp /usr/share/yubikey-luks/ykluks-defaults.cfg "${DESTDIR}/etc/ykluks-defaults.cfg"
 cp /etc/ykluks.cfg "${DESTDIR}/etc/ykluks.cfg"
 cp -pnL /usr/lib/yubikey-luks-suspend/initramfs-suspend "${DESTDIR}/suspend"
 chmod 755 "${DESTDIR}/suspend"

--- a/initramfs-suspend
+++ b/initramfs-suspend
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2013 Vianney le Clément de Saint-Marcq <vleclement@gmail.com>  
+# Copyright 2013 Vianney le Clément de Saint-Marcq <vleclement@gmail.com>
 # Copyright 2017 Zhongfu Li <me@zhongfu.li>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -29,6 +29,7 @@ sync
 echo mem > /sys/power/state
 
 # Resume root device
+. /etc/ykluks-defaults.cfg
 . /etc/ykluks.cfg
 
 [ -z "${cryptname}" ] ||
@@ -36,7 +37,7 @@ echo mem > /sys/power/state
 	P1=$(/lib/cryptsetup/askpass "$WELCOME_TEXT")
 
 	if [ "$HASH" = "1" ]; then
-		P1=$(printf %s "$P1" | sha256sum | awk '{print $1}')
+		P1=$(printf %s "$P1" | $HASH_COMMAND $HASH_ARGS | awk '{print $1}')
 	fi
 
 	R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"
@@ -46,7 +47,7 @@ echo mem > /sys/power/state
 	else
 		printf %s "$R" | cryptsetup luksResume "${cryptname}" 2>&1;
 	fi
-	
+
         [ $? -le 1 ] && break
         sleep 2
     done

--- a/key-script
+++ b/key-script
@@ -3,6 +3,7 @@
 # This is /sbin/ykluks-keyscript, which gets called when unlocking the disk
 #
 set -e
+. /etc/ykluks-defaults.cfg
 . /etc/ykluks.cfg
 
 if [ -z "$WELCOME_TEXT" ]; then
@@ -46,7 +47,7 @@ fi
 PW="$($cryptkeyscript "$WELCOME_TEXT")"
 
 if [ "$HASH" = "1" ]; then
-	PW=$(printf %s "$PW" | sha256sum | awk '{print $1}')
+	PW=$(printf %s "$PW" | $HASH_COMMAND $HASH_ARGS | awk '{print $1}')
 fi
 
 if check_yubikey_present; then

--- a/ykluks-defaults.cfg
+++ b/ykluks-defaults.cfg
@@ -1,0 +1,1 @@
+HASH_COMMAND=/usr/bin/sha256sum

--- a/ykluks.cfg
+++ b/ykluks.cfg
@@ -1,7 +1,11 @@
-# If you change this file, you need to run 
+# If you change this file, you need to run
 #   update-initramfs -u
 WELCOME_TEXT="Please insert yubikey and press enter or enter a valid passphrase"
 # Set to "1" if you want both your password and Yubikey response be bundled together and writtent to key slot.
 CONCATENATE=0
-# Set to "1" if you want to hash your password with sha256.
+# Set to "1" if you want to hash your password. The default is sha256 or you can configure an alternative hashing command with HASH_COMMAND and HASH_ARGS
 HASH=0
+# (Optional) Set to full path to the alternative hashing binary
+# HASH_COMMAND=/usr/bin/custom-hasher
+# (Optional) Set additional arguments to be passed to the hashing binary when it is called
+# HASH_ARGS="--cost=14 --salt=VB61Uj06G.lKuzqtsjg.UO"

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -5,6 +5,7 @@ CLEAR_SLOT=0
 DBG=0
 
 set -e
+. /usr/share/yubikey-luks/ykluks-defaults.cfg
 . /etc/ykluks.cfg
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -29,7 +30,7 @@ while getopts ":s:d:hcv" opt; do
 		echo "debugging enabled"
 		;;
 	h)
-		echo 
+		echo
 		echo " -d <partition>: set the partition"
 		echo " -s <slot>     : set the slot"
 		echo " -c            : clear the slot prior to writing"
@@ -63,7 +64,7 @@ if [ "$P1" != "$P2" ]; then
 fi
 
 if [ "$HASH" = "1" ]; then
-	P1=$(printf %s "$P1" | sha256sum | awk '{print $1}')
+	P1=$(printf %s "$P1" | $HASH_COMMAND $HASH_ARGS | awk '{print $1}')
 		if [ "$DBG" = "1" ]; then echo "Password hash: $P1"; fi
 fi
 

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -4,6 +4,7 @@ NAME="yubikey-luks"
 DBG=0
 
 set -e
+. /usr/share/yubikey-luks/ykluks-defaults.cfg
 . /etc/ykluks.cfg
 
 while getopts ":d:n:hv" opt; do
@@ -21,7 +22,7 @@ while getopts ":d:n:hv" opt; do
 		echo "debugging enabled"
 		;;
 	h)
-		echo 
+		echo
 		echo " -d <partition>: select existing partition"
 		echo " -n <name>     : set the new container name"
 		echo " -v            : show input/output in cleartext"
@@ -40,7 +41,7 @@ P1=$(/lib/cryptsetup/askpass "Please insert a yubikey and enter password created
 	if [ "$DBG" = "1" ]; then echo "Password: $P1"; fi
 
 if [ "$HASH" = "1" ]; then
-	P1=$(printf %s "$P1" | sha256sum | awk '{print $1}')
+	P1=$(printf %s "$P1" | $HASH_COMMAND $HASH_ARGS | awk '{print $1}')
 		if [ "$DBG" = "1" ]; then echo "Password hash: $P1"; fi
 fi
 


### PR DESCRIPTION
Add generic support for custom hashing algorithms by adding configuration options for the executable used to hash the password and arguments passed to it.

I've done basic tests on this and it works in a VM but I want to do more testing especially around suspend/resume and verify it works on bare metal. I'm posting the pull request early to see whether you're interested in accepting this feature into master and, if you are, get comments and suggestions on improvements I can make.

I have a **prototype** custom hasher **not ready for production use** implemented for bcrypt at https://github.com/wrnc/ykluks_hash_bcrypt that I've been using to test.

### New Configuration Options

`HASH_COMMAND` - A full path to the executable used to hash the password. This uses the new `ykluks-defaults.cfg` file to define the default as `/usr/bin/sha256sum` preserving backwards compatibility with config files that do not define a `HASH_COMMAND`

`HASH_ARGS` - Optional arguments that will be passed to `HASH_COMMAND` when it is run, for example a bcrypt hasher could have a mandatory salt and optional cost arguments passed or an argon2 hasher could have mandatory salt and optional time, memory, threads and derived key length arguments.