### PR TITLE
Fix fallback option in key-script

### DIFF
--- a/key-script
+++ b/key-script
@@ -43,13 +43,12 @@ fi
 
 PW="$($cryptkeyscript "$WELCOME_TEXT")"
 
-if [ "$HASH" = "1" ]; then
-	PW=$(printf %s "$PW" | sha256sum | awk '{print $1}')
-fi
-
 if check_yubikey_present; then
 	message "Accessing yubikey..."
-    R="$(ykchalresp -2 "$PW" 2>/dev/null || true)"
+	if [ "$HASH" = "1" ]; then
+        	PW=$(printf %s "$PW" | sha256sum | awk '{print $1}')
+	fi
+    	R="$(ykchalresp -2 "$PW" 2>/dev/null || true)"
 	message "Retrieved the response from the Yubikey"
 	if [ "$CONCATENATE" = "1" ]; then
 		printf '%s' "$PW$R"


### PR DESCRIPTION
We don't want to hash user password if YubiKey check failed.