### PR TITLE
Fix exit of key-script if no yubikey is present

### DIFF
--- a/key-script
+++ b/key-script
@@ -19,7 +19,7 @@ message()
     return 0
 }
 
-check_yubikey_present="$(ykinfo -q -2)"
+check_yubikey_present="$(ykinfo -q -2 2>/dev/null || true)"
 
 # source for log_*_msg() functions, see LP: #272301
 if [ -e /scripts/functions ] ; then


### PR DESCRIPTION
The current version of this script causes an exit if no yubikey is
present, thus causing no password to be prompted for at all.

This commit fixes that problem.