### PR TITLE
Remove some unused code

### DIFF
--- a/key-script
+++ b/key-script
@@ -21,25 +21,15 @@ message()
 
 check_yubikey_present="$(ykinfo -q -2)"
 
-# source for log_*_msg() functions, see LP: #272301
-if [ -e /scripts/functions ] ; then
-	. /scripts/functions
-else
-	. /usr/share/initramfs-tools/scripts/functions
-fi
-
 if [ -z "$cryptkeyscript" ]; then
-	cryptkey="Unlocking the disk $cryptsource ($crypttarget)\\nEnter passphrase: "
 	if [ -x /bin/plymouth ] && plymouth --ping; then
     	cryptkeyscript="plymouth ask-for-password --prompt"
-	    cryptkey=$(printf '%s' "$cryptkey")
     else
         cryptkeyscript="/lib/cryptsetup/askpass"
     fi
 fi
 
 PW="$($cryptkeyscript "$WELCOME_TEXT")"
-
 
 if [ "$check_yubikey_present" = "1" ]; then
 	message "Accessing yubikey..."


### PR DESCRIPTION
No need to include the initramfs-tools functions, when none of them are
used, and no need to set cryptkey, when it never is used either.