### PR TITLE
Stop exposing challenge in process list

### DIFF
--- a/initramfs-suspend
+++ b/initramfs-suspend
@@ -39,7 +39,7 @@ echo mem > /sys/power/state
 	    P1=$(printf %s "$P1" | sha256sum | awk '{print $1}')
 	fi
 
-	R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"
+	R="$(printf %s "$P1" | ykchalresp -2 -i- 2>/dev/null || true)"
 
 	if [ "$CONCATENATE" = "1" ]; then
 	    printf %s "$P1$R" | cryptsetup luksResume "${cryptname}" 2>&1;

--- a/key-script
+++ b/key-script
@@ -36,7 +36,7 @@ if [ "$check_yubikey_present" = "1" ]; then
     if [ "$HASH" = "1" ]; then
         PW=$(printf %s "$PW" | sha256sum | awk '{print $1}')
     fi
-    R="$(ykchalresp -2 "$PW" 2>/dev/null || true)"
+    R="$(printf %s "$PW" | ykchalresp -2 -i- 2>/dev/null || true)"
     if [ "$R" ]; then
         message "Retrieved the response from the Yubikey"
 		    if [ "$CONCATENATE" = "1" ]; then

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -89,7 +89,7 @@ if [ "$HASH" = "1" ]; then
     if [ "$DBG" = "1" ]; then echo "Password hash: $P1"; fi
 fi
 
-R="$(printf %s "$PW" | ykchalresp -"$YUBIKEY_LUKS_SLOT" -i- 2>/dev/null || true)"
+R="$(printf %s "$P1" | ykchalresp -"$YUBIKEY_LUKS_SLOT" -i- 2>/dev/null || true)"
 if [ "$DBG" = "1" ]; then echo "Yubikey response: $R"; fi
 
 if [ -z "$R" ]; then

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -74,7 +74,7 @@ if [ "$HASH" = "1" ]; then
     if [ "$DBG" = "1" ]; then echo "Password hash: $P1"; fi
 fi
 
-R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"
+R="$(printf %s "$P1" | ykchalresp -2 -i- 2>/dev/null || true)"
 if [ "$DBG" = "1" ]; then echo "Yubikey response: $R"; fi
 
 if [ -z "$R" ]; then

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -51,7 +51,7 @@ if [ "$HASH" = "1" ]; then
     if [ "$DBG" = "1" ]; then echo "Password hash: $P1"; fi
 fi
 
-R="$(printf %s "$PW" | ykchalresp -"$YUBIKEY_LUKS_SLOT" -i- 2>/dev/null || true)"
+R="$(printf %s "$P1" | ykchalresp -"$YUBIKEY_LUKS_SLOT" -i- 2>/dev/null || true)"
 if [ "$DBG" = "1" ]; then echo "Yubikey response: $R"; fi
 
 if [ -z "$R" ]; then

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -50,7 +50,7 @@ if [ "$HASH" = "1" ]; then
     if [ "$DBG" = "1" ]; then echo "Password hash: $P1"; fi
 fi
 
-R="$(ykchalresp -2 "$P1" 2>/dev/null || true)"
+R="$(printf %s "$P1" | ykchalresp -2 -i- 2>/dev/null || true)"
 if [ "$DBG" = "1" ]; then echo "Yubikey response: $R"; fi
 
 if [ -z "$R" ]; then


### PR DESCRIPTION
Passing challenge as argument to `ykchalresp` results in it being
exposed in process list, i.e. `ps aux`. Piping challenge through
stdin fixes that.

Fixes https://github.com/cornelinux/yubikey-luks/issues/51