### PR TITLE
Fix file permissions on `/etc/ykluks.cfg`

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,7 @@ override_dh_install:
 	install -D -o root -g root -m755 yubikey-luks-enroll debian/yubikey-luks/usr/bin/yubikey-luks-enroll
 	install -D -o root -g root -m644 yubikey-luks-enroll.1 debian/yubikey-luks/usr/man/man1/yubikey-luks-enroll.1
 	install -D -o root -g root -m644 README.md debian/yubikey-luks/usr/share/doc/yubikey-luks/README.md
-	install -D -o root -g root -m644 ykluks.cfg debian/yubikey-luks/etc/ykluks.cfg
+	install -D -o root -g root -m640 ykluks.cfg debian/yubikey-luks/etc/ykluks.cfg
 	install -D -o root -g root -m755 yubikey-luks-suspend debian/yubikey-luks/usr/lib/yubikey-luks/yubikey-luks-suspend
 	install -D -o root -g root -m755 initramfs-suspend debian/yubikey-luks/usr/lib/yubikey-luks/initramfs-suspend
 	install -D -o root -g root -m644 yubikey-luks-suspend.service debian/yubikey-luks/lib/systemd/system/yubikey-luks-suspend.service


### PR DESCRIPTION
As `/etc/ykluks.cfg` may contain a yubikey challenge password, it shouldn't be non-root user readable by default.