### PR TITLE
yubikey-luks-suspend: do lazy umounts

### DIFF
--- a/yubikey-luks-suspend
+++ b/yubikey-luks-suspend
@@ -48,7 +48,7 @@ mount_barrier() {
 umount_bind() {
     local p
     for p in ${BIND_PATHS}; do
-        mountpoint -q "${INITRAMFS_DIR}${p}" && umount "${INITRAMFS_DIR}${p}"
+        mountpoint -q "${INITRAMFS_DIR}${p}" && umount -l "${INITRAMFS_DIR}${p}"
     done
 }
 


### PR DESCRIPTION
Mountpoints may be busy for short period of time, using lazy option for umount will prevent script failure in such scenario.

Fixes https://github.com/cornelinux/yubikey-luks/issues/68