### PR TITLE
Test for valid LUKS device

### DIFF
--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -58,6 +58,11 @@ while getopts ":s:d:y:hcv" opt; do
     esac
 done
 
+if ! cryptsetup isLuks "$DISK"; then
+    echo "Device is not a valid LUKS partition, bailing." >&2
+    exit 1
+fi
+
 echo "This script will utilize the YubiKey slot $YUBIKEY_LUKS_SLOT for slot $SLOT on drive $DISK.  If this is not what you intended, exit now!"
 
 if [ "$CLEAR_SLOT" = "1" ]; then

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -35,6 +35,11 @@ while getopts ":d:n:hv" opt; do
     esac
 done
 
+if ! cryptsetup isLuks "$DISK"; then
+    echo "Device is not a valid LUKS partition, bailing." >&2
+    exit 1
+fi
+
 echo "This script will try opening $NAME LUKS container on drive $DISK . If this is not what you intended, exit now!"
 
 while true ; do


### PR DESCRIPTION
As is, the luks enroll and luks-open script ask for passwords before determining if the device is even valid.  cryptsetup provides a method for testing if a partition is valid LUKS.  This patch adds that functionality to the yubikey-luks-open and yubikey-luks-enroll scripts.  