### PR TITLE
Added 1FA hardware hash support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ If you set CONCATENATE=1 option in the file /etc/ykluks.cfg then both your passw
 If you set HASH=1 option in the file /etc/ykluks.cfg then your password will be hashed with sha256 algorithm before using as challenge for yubikey: printf password | sha256sum | awk '{print $1}'
 5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
 
+
 Changing the welcome text
 -------------------------
 
@@ -62,8 +63,8 @@ After changing this file, you need to run
 
 so that the changes get transferred to the initramfs.
 
-Use 1FA to allow unattended, passwordless boot 
-----------------------------------------------
+Use "weak" 1FA to allow unattended, passwordless boot on any hardware
+---------------------------------------------------------------------
 
 In order to bypass the password prompt and allow the system to boot when the paired Yubikey is present without requiring interactive input of the challenge password, then you must edit /etc/ykluks.cfg to contain the challenge password that you previously enrolled (and which should be bypassed). Example: 
 
@@ -79,6 +80,24 @@ After changing this file, you need to run
 
 so that the changes get transferred to the initramfs.
 
+Use "more-secure" 1FA to allow passwordless boot only on certain hardware
+-------------------------------------------------------------------------
+
+In order to bypass the password prompt and allow the system to boot when the paired Yubikey is present without requiring interactive input of the challenge password, the challenge password is calculated based on a hash of the output of a command which returns hardware info and serial numbers (`dmidecode -t system`). To enable, uncomment this line in /etc/ykluks.cfg
+
+    YUBIKEY_CHALLENGE_HARDWARE_HASH=1
+
+The challenge password is calculated based off the hash of the dmidecode output like this:
+
+    dmidecode -t system | sha256sum | awk '{print $1}')
+
+Notes: 
+ - To make this work with multiple machines, run `yubikey-luks-enroll -s <LUKS slot>` with a different LUKS slot for each machine (default is 7). 
+ - An added degree of security is optained as an attacker will need access to all of: 
+   - Your bootable medium (eg your SSD)
+   - Computer that you use (for the `dmidecode` output)
+   - Yubikey in order to decrypt the LUKS encrypted partition
+ - The `YUBIKEY_CHALLENGE` setting has no effect if `YUBIKEY_CHALLENGE_HARDWARE_HASH=1` uncommented
 
 Enable yubikey-luks initramfs module
 ------------------------------------

--- a/hook
+++ b/hook
@@ -22,6 +22,7 @@ esac
 copy_exec /usr/bin/ykchalresp
 copy_exec /usr/bin/ykinfo
 copy_exec /usr/bin/sha256sum
+if [ -n "$YUBIKEY_CHALLENGE_HARDWARE_HASH" ]; then copy_exec /usr/sbin/dmidecode; fi
 cp /usr/share/yubikey-luks/ykluks-keyscript "${DESTDIR}/sbin/ykluks-keyscript"
 cp /etc/ykluks.cfg "${DESTDIR}/etc/ykluks.cfg"
 

--- a/initramfs-suspend
+++ b/initramfs-suspend
@@ -34,7 +34,11 @@ echo mem > /sys/power/state
 
 [ -z "${cryptname}" ] ||
     while true; do
-        P1=$(/lib/cryptsetup/askpass "$WELCOME_TEXT")
+        if [ "$YUBIKEY_CHALLENGE_HARDWARE_HASH" == "1" ]; then
+            P1="$(dmidecode -t system | sha256sum | awk '{print $1}')"
+        else
+            P1=$(/lib/cryptsetup/askpass "$WELCOME_TEXT")
+        fi
 
         if [ "$HASH" = "1" ]; then
             P1=$(printf %s "$P1" | sha256sum | awk '{print $1}')

--- a/key-script
+++ b/key-script
@@ -22,7 +22,7 @@ message()
 
 check_yubikey_present="$(ykinfo -q -"$YUBIKEY_LUKS_SLOT")"
 
-if [ -z "$YUBIKEY_CHALLENGE" ] || [ "$check_yubikey_present" != "1" ] ; then
+if { [ -z "$YUBIKEY_CHALLENGE" ] && [ "$YUBIKEY_CHALLENGE_HARDWARE_HASH" != "1" ]; } || [ "$check_yubikey_present" != "1" ] ; then
   if [ -z "$cryptkeyscript" ]; then
       if [ -x /bin/plymouth ] && plymouth --ping; then
           cryptkeyscript="plymouth ask-for-password --prompt"
@@ -32,7 +32,11 @@ if [ -z "$YUBIKEY_CHALLENGE" ] || [ "$check_yubikey_present" != "1" ] ; then
   fi
   PW="$($cryptkeyscript "$WELCOME_TEXT")"
 else
-  PW="$YUBIKEY_CHALLENGE"
+    if [ "$YUBIKEY_CHALLENGE_HARDWARE_HASH" == "1" ]; then
+        PW="$(dmidecode -t system | sha256sum | awk '{print $1}')"
+    else
+        PW="$YUBIKEY_CHALLENGE"
+    fi
 fi
 
 if [ "$check_yubikey_present" = "1" ]; then
@@ -52,7 +56,7 @@ if [ "$check_yubikey_present" = "1" ]; then
         message "Failed to retrieve the response from the Yubikey"
     fi
 else
-        printf '%s' "$PW"
+    printf '%s' "$PW"
 fi
 
 exit 0

--- a/ykluks.cfg
+++ b/ykluks.cfg
@@ -27,3 +27,8 @@ SUSPEND=0
 # for an unattended boot so long as the Yubikey is present.
 # Leave this empty (or unset), if you want to do 2FA -- i.e. being asked for the password during boot time.
 # YUBIKEY_CHALLENGE="password"
+
+# Uncomment this line if you want to use a hash of the `dmidecode` output instead of the 'YUBIKEY_CHALLENGE' password (above)
+# If this line is uncommented then 'YUBIKEY_CHALLENGE' has no effect and 1FA is enabled
+# This is designed to give a slightly more secure 1FA experience however it prevents the ubikey from unlocking the luks partition on unknown hardware
+# YUBIKEY_CHALLENGE_HARDWARE_HASH=1

--- a/yubikey-luks-enroll
+++ b/yubikey-luks-enroll
@@ -73,15 +73,21 @@ while true ; do
     read -r _ <&1
 done
 
-P1=$(/lib/cryptsetup/askpass "Please enter the yubikey challenge password. This is the password that will only work while your yubikey is installed in your computer:")
-if [ "$DBG" = "1" ]; then echo "Password: $P1"; fi
+if [ "$YUBIKEY_CHALLENGE_HARDWARE_HASH" = "1" ]; then
+    if ! command -v dmidecode > /dev/null; then echo "dmidecode could not be found, please install it"; exit 1; fi
+    P1="$(dmidecode -t system | sha256sum | awk '{print $1}')"
+    if [ "$DBG" = "1" ]; then echo "Using Password: $P1"; fi
+else
+    P1=$(/lib/cryptsetup/askpass "Please enter the yubikey challenge password. This is the password that will only work while your yubikey is installed in your computer:")
+    if [ "$DBG" = "1" ]; then echo "Password: $P1"; fi
 
-P2=$(/lib/cryptsetup/askpass "Please enter the yubikey challenge password again:")
-if [ "$DBG" = "1" ]; then echo "Password: $P2"; fi
+    P2=$(/lib/cryptsetup/askpass "Please enter the yubikey challenge password again:")
+    if [ "$DBG" = "1" ]; then echo "Password: $P2"; fi
 
-if [ "$P1" != "$P2" ]; then
-    echo "Passwords do not match"
-    exit 1
+    if [ "$P1" != "$P2" ]; then
+        echo "Passwords do not match"
+        exit 1
+    fi
 fi
 
 if [ "$HASH" = "1" ]; then

--- a/yubikey-luks-open
+++ b/yubikey-luks-open
@@ -43,8 +43,13 @@ while true ; do
     read -r _ <&1
 done
 
-P1=$(/lib/cryptsetup/askpass "Enter password created with yubikey-luks-enroll:")
-if [ "$DBG" = "1" ]; then echo "Password: $P1"; fi
+if [ "$YUBIKEY_CHALLENGE_HARDWARE_HASH" = "1" ]; then
+    P1="$(dmidecode -t system | sha256sum | awk '{print $1}')"
+    if [ "$DBG" = "1" ]; then echo "Using Password: $P1"; fi
+else
+    P1=$(/lib/cryptsetup/askpass "Enter password created with yubikey-luks-enroll:")
+    if [ "$DBG" = "1" ]; then echo "Password: $P1"; fi
+fi
 
 if [ "$HASH" = "1" ]; then
     P1=$(printf %s "$P1" | sha256sum | awk '{print $1}')


### PR DESCRIPTION
# Overview
As noted in the [Readme](https://github.com/cornelinux/yubikey-luks#use-1fa-to-allow-unattended-passwordless-boot) 1FA offers weaker security as an attacker only needs to gain access to your bootable medium and yubikey to be able to decrypt luks partitions. 1FA authentication with a hardware-based hash aims to add an additional degree of security by using a hash of the hardware info (eg serial numbers) as the challenge password. This improves security if your bootable medium is different from the machine you boot off (eg a laptop and usb drive) as an attacker would need to get a hold of your laptop as well as your usb and yubikey.

In my case, I use a portable SSD as a bootable medium which can be prone to getting lost. With 1FA w/ hardware hash I am able to boot use passwordless boot on two of my laptops while any other device requires the original LUKS password. Yes someone could decrypt my SSD without a password, however it would require aquiring my laptop, yubikey and SSD.

# How it works
## How is the hardware hash calulated
`dmidecode -t system | sha256sum | awk '{print $1}')`

`dmidecode` prints the manufacturer, product name, serial number and uuid for your laptop/computer. It is then hashed with sha256 and used as the challenge password

[See this line for an example](https://github.com/Samdaaman/yubikey-luks/blob/add-hardware-hash-support/key-script#L36)

## Multiple devices?
To use multiple devices with this method, you must run `yubikey-luks-enroll` on each device and change the LUKS slot (-s option) each time. Since each device has a unqiue serial, it will have a unique challenge password and response and therefore must have an individual keyslot.

# Links
[I found this issue where the idea is mentioned](https://github.com/cornelinux/yubikey-luks/issues/70)