### PR TITLE
Use single quotes in ykluks.cfg for YUBIKEY_CHALLENGE

### DIFF
--- a/ykluks.cfg
+++ b/ykluks.cfg
@@ -26,4 +26,4 @@ SUSPEND=0
 # a normal password. This is weaker than 2-factor authentication, but allows 
 # for an unattended boot so long as the Yubikey is present.
 # Leave this empty (or unset), if you want to do 2FA -- i.e. being asked for the password during boot time.
-# YUBIKEY_CHALLENGE="password"
+# YUBIKEY_CHALLENGE='password'


### PR DESCRIPTION
The `YUBIKEY_CHALLENGE` default (commented out) value in `ykluks.cfg` uses double quotes.

I encountered a confusing failure because I used a challenge value generated by my password manager, that included `$` and other characters that will break a double quote string in bash.

Using single quotes around the challenge value fixed the issue.

Fixes #97 